### PR TITLE
update types

### DIFF
--- a/generated/go/entity.go
+++ b/generated/go/entity.go
@@ -61,7 +61,7 @@ type GetEntity struct {
 	// Filters shipment relationships to a trade partner name
 	RelationshipsPartnerName *string `json:"-"`
 	// Filters shipment relationships to a trade partner [risk tag](/sayari-library/ontology/enumerated-types#tag)
-	RelationshipsPartnerRisk []*Tag `json:"-"`
+	RelationshipsPartnerRisk []*Risk `json:"-"`
 	// Filters shipment relationships to an HS code
 	RelationshipsHsCode *string `json:"-"`
 	// The pagination token for the next page of possibly same entities.

--- a/generated/go/search.go
+++ b/generated/go/search.go
@@ -118,7 +118,7 @@ type FilterList struct {
 	City       []string   `json:"city,omitempty"`
 	EntityType []Entities `json:"entity_type,omitempty"`
 	Bounds     []string   `json:"bounds,omitempty"`
-	Risk       []Tag      `json:"risk,omitempty"`
+	Risk       []Risk     `json:"risk,omitempty"`
 
 	_rawJSON json.RawMessage
 }

--- a/generated/go/types.go
+++ b/generated/go/types.go
@@ -294,7 +294,7 @@ type AddressProperties struct {
 	// The address value transliterated to English
 	Transliterated *string `json:"transliterated,omitempty"`
 	// Indicates what the address is referring to. For example, it could be a physical address, mailing address, or other address type.
-	Type *AddressType `json:"type,omitempty"`
+	Type *string `json:"type,omitempty"`
 	// An apartment, unit, office, lot, or other secondary unit designator
 	Unit  *string `json:"unit,omitempty"`
 	Value *string `json:"value,omitempty"`


### PR DESCRIPTION
use risk instead of risk tag, also includes earlier update to be less strict about address type